### PR TITLE
Improve API key setup handling

### DIFF
--- a/main.py
+++ b/main.py
@@ -118,7 +118,7 @@ def main():
     # Загрузка переменных окружения
     load_dotenv()
     api_key = os.getenv("GEMINI_API_KEY")
-    if not api_key:
+    if not api_key or len(api_key) < 50:
         logger.error("GEMINI_API_KEY not found in environment.")
         env_path = os.path.join(os.getcwd(), ".env")
         _ensure_env_file(env_path)

--- a/main.py
+++ b/main.py
@@ -1,6 +1,8 @@
 import os
 import sys
 from tkinter import messagebox
+import webbrowser
+import subprocess
 
 from loguru import logger
 from dotenv import load_dotenv
@@ -10,6 +12,80 @@ from app_gui import AutoReclipperApp
 # Константы
 LOG_FILE = "autoreclipper.log"
 LOG_ERROR_FILE = "autoreclipper_error.log"
+
+
+def _ensure_env_file(env_path: str) -> None:
+    """Create .env file with placeholder if it is missing or lacks the key."""
+    placeholder = 'GEMINI_API_KEY="YOUR_API_KEY_HERE"\n'
+    if not os.path.exists(env_path):
+        with open(env_path, "w", encoding="utf-8") as f:
+            f.write(placeholder)
+        logger.info("Created .env file with API key placeholder.")
+        return
+    try:
+        with open(env_path, "r", encoding="utf-8") as f:
+            content = f.read()
+        if "GEMINI_API_KEY" not in content:
+            with open(env_path, "a", encoding="utf-8") as f:
+                if not content.endswith("\n"):
+                    f.write("\n")
+                f.write(placeholder)
+            logger.info("Added API key placeholder to existing .env file.")
+    except IOError as e:
+        logger.error(f"Failed to prepare .env file: {e}")
+
+
+def _open_file_default(path: str) -> None:
+    """Open a file with the default text editor."""
+    try:
+        if sys.platform.startswith("win"):
+            os.startfile(path)  # type: ignore[attr-defined]
+        elif sys.platform.startswith("darwin"):
+            subprocess.Popen(["open", path])
+        else:
+            subprocess.Popen(["xdg-open", path])
+    except Exception as e:
+        logger.error(f"Failed to open file {path}: {e}")
+
+
+def _prompt_api_key_setup(env_path: str) -> None:
+    """Show a modal dialog instructing the user to add the API key."""
+    import tkinter as tk
+
+    root = tk.Tk()
+    root.title("GEMINI_API_KEY Required")
+    root.resizable(False, False)
+
+    label = tk.Label(
+        root,
+        text=(
+            "Generate a Google Gemini API key, paste it into .env and save.\n"
+            "Сгенерируйте API ключ, вставьте его в .env и сохраните."
+        ),
+        justify="center",
+        wraplength=360,
+    )
+    label.pack(padx=20, pady=10)
+
+    frame = tk.Frame(root)
+    frame.pack(pady=5)
+
+    def go():
+        webbrowser.open(
+            "https://www.google.com/search?q=how+to+get+google+gemini+api+key+for+free"
+        )
+        _open_file_default(env_path)
+        root.destroy()
+
+    def cancel():
+        root.destroy()
+
+    go_btn = tk.Button(frame, text="GO", width=10, command=go)
+    cancel_btn = tk.Button(frame, text="Cancel", width=10, command=cancel)
+    go_btn.pack(side="left", padx=10)
+    cancel_btn.pack(side="left", padx=10)
+
+    root.mainloop()
 
 def setup_logging():
     """Настраивает систему логирования с использованием Loguru."""
@@ -34,24 +110,19 @@ def setup_logging():
     
     logger.info("Logging is configured.")
 
+
 def main():
     """Основная функция для запуска приложения. Main application launch function."""
     setup_logging()
 
     # Загрузка переменных окружения
     load_dotenv()
-    if not os.getenv("GEMINI_API_KEY"):
-        logger.error("GEMINI_API_KEY not found in .env file.")
-        # Поскольку GUI еще не запущен, используем стандартный messagebox
-        import tkinter as tk
-        root = tk.Tk()
-        root.withdraw()
-        messagebox.showerror(
-            "API Key Error",
-            "The GEMINI_API_KEY was not found in the .env file. Please add it and restart the application.\n"
-            "GEMINI_API_KEY не найден в файле .env. Пожалуйста, добавьте его и перезапустите приложение."
-        )
-        root.destroy()
+    api_key = os.getenv("GEMINI_API_KEY")
+    if not api_key:
+        logger.error("GEMINI_API_KEY not found in environment.")
+        env_path = os.path.join(os.getcwd(), ".env")
+        _ensure_env_file(env_path)
+        _prompt_api_key_setup(env_path)
         return
 
     try:
@@ -62,6 +133,7 @@ def main():
         messagebox.showerror("Critical Error", f"Произошла критическая ошибка: {e}\n\nСмотрите {LOG_ERROR_FILE} для деталей.")
     finally:
         logger.info("Application shutting down.")
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- create helper to generate `.env` if missing
- show modal with GO/Cancel buttons when `GEMINI_API_KEY` is absent
- open default text editor and Google search from modal

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_6857c3af611c83208a4e4406b00c358b